### PR TITLE
Resolves issue 8

### DIFF
--- a/payment_rave/static/src/js/rave.js
+++ b/payment_rave/static/src/js/rave.js
@@ -24,7 +24,9 @@ odoo.define('payment_rave.rave', function(require) {
             customer_phone: phone,
             currency: currency,
             txref: invoice_num,
-            onclose: function() {},
+            onclose: function() {
+                window.location = "/shop/payment";
+            },
             callback: function(response) {
                 var txref = response.tx.txRef; // collect txRef returned and pass to a 					server page to complete status check.
                 if ($.blockUI) {

--- a/static/src/js/rave.js
+++ b/static/src/js/rave.js
@@ -24,7 +24,9 @@ odoo.define('payment_rave.rave', function(require) {
             customer_phone: phone,
             currency: currency,
             txref: invoice_num,
-            onclose: function() {},
+            onclose: function() {
+                window.location = "/shop/payment";
+            },
             callback: function(response) {
                 var txref = response.tx.txRef; // collect txRef returned and pass to a 					server page to complete status check.
                 if ($.blockUI) {


### PR DESCRIPTION
When the payment pop-up is closed, the payment page is reloaded, to release other payment dependent scripts.
Closes: #8